### PR TITLE
Update Uberwriter -> Apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ This is a list of native, open source [GTK](https://en.wikipedia.org/wiki/GTK%2B
 
 - [Marker](https://github.com/fabiocolacio/Marker) #c
 - [Showdown](https://github.com/craigbarnes/showdown) #vala
-- [Uberwriter](https://github.com/wolfv/uberwriter) #python
+- [Apostrophe](https://gitlab.gnome.org/somas/apostrophe) #python
 - [markdown-rs](https://github.com/nilgradisnik/markdown-rs) #rust
 - [Quilter](https://github.com/lainsce/quilter) #vala #granite
 


### PR DESCRIPTION
Uberwriter changed name some time ago, and it was moved to the GNOME Gitlab instance
This PR reflects that