### PR TITLE
Add Kazam2 and tag LibreOffice and Inkscape as GTK3

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 
 - [Birdfont](https://github.com/johanmattssonm/birdfont) - Font editor for creating fonts in TTF, EOT, SVG and BIRDFONT formats `#vala` `#gtk3`.
 - [Font Downloader](https://github.com/GustavoPeredo/font-downloader) - Download utility for Google Fonts `#python` `#gtk3` `#libhandy`.
-- [Inkscape](https://inkscape.org) - General vector graphics editor using GTK since version 1.0 `#c++` `#gtk4`.
+- [Inkscape](https://inkscape.org) - General vector graphics editor using GTK since version 1.0 `#c++` `#gtk3`.
 - [Mingle](https://github.com/halfmexican/mingle) - Application to combine emojis using Google's Emoji Kitchen `#vala` `#gtk4` `#libadwaita`.
 - [Pizzara](https://pizarra.categulario.xyz/en) - Digital, vectorial and infinite chalkboard for free-hand drawing `#rust` `#gtk3`.
 - [Webfont Kit Generator](https://apps.gnome.org/WebfontKitGenerator) - Utility to create web font-face kits `#python` `#gtk4` `#libadwaita` `#gnome`.
@@ -462,7 +462,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 ### Office Suites
 
-- [LibreOffice](https://www.libreoffice.org) - Cross-platform office suite using the OpenDocument format and supports variety of formats including Microsoft Office `#C++` `#gtk4`.
+- [LibreOffice](https://www.libreoffice.org) - Cross-platform office suite using the OpenDocument format and supports variety of formats including Microsoft Office `#C++` `#gtk3`.
 
 ### Book Readers
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 
 ### Screen Recorders
 
+- [Kazam2](https://github.com/henrywoo/kazam) - Linux Screen Recorder, Broadcaster, Capture and OCR with AI `#python` `#gtk3`.
 - [Kooha](https://github.com/SeaDve/Kooha) - Distraction-free screen recorder `#rust` `#gtk4` `#libadwaita`.
 - [RecApp](https://github.com/amikha1lov/RecApp) - (archived) Simple screencasting application based on GStreamer `#python` `#gtk3` `#libhandy`.
 

--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 #### Simple Editors and Light IDEs
 
+- [Bluefish](https://bluefish.openoffice.nl) - Editor targeted towards programmers and web developers (C, JavaScript, Java, PHP, Python, markup languages HTML, YAML and XML) `#c` `#gtk3`.
 - [elementary Code](https://github.com/elementary/code) - Code editor designed for elementaryOS `#vala` `#gtk3` `#granite` `#elementary`.
 - [elementary IDE](https://github.com/donadigo/elementary-ide) - Unofficial elementaryOS-oriented IDE `#vala` `#gtk3` `#granite`.
 - [Geany](https://www.geany.org) - Cross-platform ext editor that provides tons of useful features `#c` `#gtk3`.

--- a/README.md
+++ b/README.md
@@ -690,7 +690,6 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 #### Simple Editors and Light IDEs
 
-
 - [Bluefish](https://bluefish.openoffice.nl) - Editor targeted towards programmers and web developers (C, JavaScript, Java, PHP, Python and markup languages: HTML, YAML and XML) `#c` `#gtk3`.
 - [elementary Code](https://github.com/elementary/code) - Code editor designed for elementaryOS `#vala` `#gtk3` `#granite` `#elementary`.
 - [elementary IDE](https://github.com/donadigo/elementary-ide) - Unofficial elementaryOS-oriented IDE `#vala` `#gtk3` `#granite`.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 
 ### Screen Recorders
 
-- [Kazam2](https://github.com/henrywoo/kazam) - Linux Screen Recorder, Broadcaster, Capture and OCR with AI `#python` `#gtk3`.
+- [Kazam2](https://github.com/henrywoo/kazam) - Versatile tool for screen recording, broadcasting, capturing and optical character recognition `#python` `#gtk3`.
 - [Kooha](https://github.com/SeaDve/Kooha) - Distraction-free screen recorder `#rust` `#gtk4` `#libadwaita`.
 - [RecApp](https://github.com/amikha1lov/RecApp) - (archived) Simple screencasting application based on GStreamer `#python` `#gtk3` `#libhandy`.
 


### PR DESCRIPTION
Pull request 2: I don't know if I messed it up this time:

I wanted to have a pull request for the following issues, but I think I requested again the old change in Bluefish (which I had already pulled and you requested a change). 

Anyhow, I intended to have my second pull request for these two changes:

(1) Change: Both LibreOffice and Inkscape are still GTK3:
LibreOffice is still GTK3. GTK4 is in development with no clear timeframe. The GTK4 port is not yet finished.
Inkscape just released v1.4 on basis of GTK3. The next release v1.5 will be based on GTK4, but there is no alpha or beta yet.

(2) Added: Kazam2 - Linux Screen Recorder, Broadcaster, Capture and OCR with AI
https://github.com/henrywoo/kazam
#Python #GTK3
Kazam 2.0 is a versatile tool for screen recording, broadcasting, capturing and optical character recognition(OCR).