### PR TITLE
Clapper is now GTK4 and libadwaita

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 #### Simple Editors and Light IDEs
 
+- [Bluefish](https://bluefish.openoffice.nl) - Editor targeted towards programmers and web developers (C, JavaScript, Java, PHP, Python, markup languages HTML, YAML and XML) `#c` `#gtk3`.
 - [elementary Code](https://github.com/elementary/code) - Code editor designed for elementaryOS `#vala` `#gtk3` `#granite` `#elementary`.
 - [elementary IDE](https://github.com/donadigo/elementary-ide) - Unofficial elementaryOS-oriented IDE `#vala` `#gtk3` `#granite`.
 - [Geany](https://www.geany.org) - Cross-platform ext editor that provides tons of useful features `#c` `#gtk3`.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 ### Video Players
 
 - [Celluloid](https://github.com/celluloid-player/celluloid) - (ex GNOME MPV) frontend for MPV `#c` `#gtk4` `#libadwaita`.
-- [Clapper](https://github.com/Rafostar/clapper) - Media player powered by GStreamer with OpenGL rendering `#gjs` `#c` `#gtk3`.
+- [Clapper](https://github.com/Rafostar/clapper) - Media player powered by GStreamer with OpenGL rendering `#gjs` `#c` `#gtk4` #libadwaita`.
 - [Delfin](https://codeberg.org/avery42/delfin) - Application to stream movies/TV shows from Jellyfin `#rust` `#gtk4` `#libadwaita`.
 - [GNOME Videos](https://apps.gnome.org/Totem) - Official GNOME desktop video player, also known as Totem `#c` `#gtk3`. `#gnome`.
 - [Glide](https://github.com/philn/glide) - Simple video player powered by GStreamer `#rust` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 #### Simple Editors and Light IDEs
 
-- [Bluefish](https://bluefish.openoffice.nl) - Editor targeted towards programmers and web developers (C, JavaScript, Java, PHP, Python, markup languages HTML, YAML and XML) `#c` `#gtk3`.
+- [Bluefish](https://bluefish.openoffice.nl) - Editor targeted towards programmers and web developers (C, JavaScript, Java, PHP, Python and markup languages: HTML, YAML and XML) `#c` `#gtk3`.
 - [elementary Code](https://github.com/elementary/code) - Code editor designed for elementaryOS `#vala` `#gtk3` `#granite` `#elementary`.
 - [elementary IDE](https://github.com/donadigo/elementary-ide) - Unofficial elementaryOS-oriented IDE `#vala` `#gtk3` `#granite`.
 - [Geany](https://www.geany.org) - Cross-platform ext editor that provides tons of useful features `#c` `#gtk3`.


### PR DESCRIPTION
Clapper is now GTK4 and libadwaita, Update information

https://github.com/Rafostar/clapper/tree/master -> explains that the application is GTK4

https://github.com/Rafostar/clapper/blob/master/meson.build
has GTK4 and libadwaita dependencies