### PR TITLE
Add RS-Paint

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [MyPaint](http://mypaint.org) - Simple drawing and painting program with support for Wacom-style graphics tablets `#python` `#gtk3`.
 - [Obfuscate](https://apps.gnome.org/Obfuscate) - Private information censoring tool `#rust` `#gtk4` `#libadwaita` `#gnome`.
 - [Pinta](https://www.pinta-project.com) - Drawing and image editing program with simple interface and layered organization `#c#` `#gtk3`.
+- [RS-Paint](https://github.com/lucasscharenbroch/rs-paint) - A light-weight image editor inspired by MS-Paint `#rust` `#gtk4`.
 - [Swappy](https://github.com/jtheoof/swappy) - Wayland native screenshot editing tool `#c` `#gtk3`.
 
 [imagemagick]: https://imagemagick.org


### PR DESCRIPTION
RS-Paint - A light-weight image editor written in Rust using GTK4

Rust GTK4

Goals
    Match the intuition and simplicity of MS-Paint
    Add core features and ergonomics MS-Paint lacks
    Be cross-platform, free, and open-source

It released version 1.0 yesterday.

https://lib.rs/crates/rs-paint
https://github.com/lucasscharenbroch/rs-paint