### PR TITLE
Add Decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [StreamController](https://github.com/StreamController/StreamController) - Elgato Stream Deck controller with support for plugins `#python` `#gtk4` `#libadwaita`.
 - [Cigale](https://github.com/emmanueltouzery/cigale) - Timesheet for your activities with support for emails, Git, GitLab and Stack Exchange `#rust` `#gtk3` `#relm`.
 - [Collector](https://mijorus.it/projects/collector) - Dropover utility that allows to drag files/images/text into a collection window and drop them anywhere `#python` `#gtk4` `#libadwaita`.
+- [Decoder](https://apps.gnome.org/Decoder/) - QR Codes scanner and generator `#rust` `#gtk4` `#libadwaita` `#gnome`.
 - [GNOME Characters](https://apps.gnome.org/Characters) - Emoji picker `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Morphosis](https://gitlab.gnome.org/World/morphosis) - Document converter (using Pandoc) supporting PDF, Markdown, RST, LaTeX, HTML, Microsoft Word, Open/Libre Office and EPUB formats `#python` `#gtk4` `#libadwaita`. 
 - [Notify](https://github.com/ranfdev/Notify) - Client for ntfy `#rust` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [StreamController](https://github.com/StreamController/StreamController) - Elgato Stream Deck controller with support for plugins `#python` `#gtk4` `#libadwaita`.
 - [Cigale](https://github.com/emmanueltouzery/cigale) - Timesheet for your activities with support for emails, Git, GitLab and Stack Exchange `#rust` `#gtk3` `#relm`.
 - [Collector](https://mijorus.it/projects/collector) - Dropover utility that allows to drag files/images/text into a collection window and drop them anywhere `#python` `#gtk4` `#libadwaita`.
-- [Decoder](https://apps.gnome.org/Decoder/) - QR Codes scanner and generator `#rust` `#gtk4` `#libadwaita` `#gnome`.
+- [Decoder](https://apps.gnome.org/Decoder) - QR Codes scanner and generator `#rust` `#gtk4` `#libadwaita` `#gnome`.
 - [GNOME Characters](https://apps.gnome.org/Characters) - Emoji picker `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Morphosis](https://gitlab.gnome.org/World/morphosis) - Document converter (using Pandoc) supporting PDF, Markdown, RST, LaTeX, HTML, Microsoft Word, Open/Libre Office and EPUB formats `#python` `#gtk4` `#libadwaita`. 
 - [Notify](https://github.com/ranfdev/Notify) - Client for ntfy `#rust` `#gtk4` `#libadwaita`.


### PR DESCRIPTION
Decoder - QR Codes scanner and generator
https://apps.gnome.org/Decoder
https://gitlab.gnome.org/World/decoder
rust gtk4 libadwaita 
Gnome circle app

I wasn't sure in which category it fits, that's why I put it into desktop productivity. The program itself uses the tags Scanning Utility. This might be a new category, because, for example, also SimpleScan (aka Document Scanner) https://apps.gnome.org/SimpleScan/ https://gitlab.gnome.org/GNOME/simple-scan is missing in the list, which is a Gnome Core app (#vala #gtk4 #libadwaita #gnome). So maybe one could open a new category scanning utilities?