### PR TITLE
Add gscan2pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 - [Decoder](https://apps.gnome.org/Decoder) - QR Codes scanner and generator `#rust` `#gtk4` `#libadwaita` `#gnome`.
 - [Document Scanner (SimpleScan)](https://apps.gnome.org/SimpleScan) - Document scanner using the SANE framework with crop and rotate editing features `#vala` `#gtk4``#libadwaita` `#gnome`.
-- [gscan2pdf](https://gscan2pdf.sourceforge.net/) - Document scanner that can scan, clean the scan and do OCR on the scan or imported images (incl. existing PDFs, DjVus or other file types), and make PDF and DjVu-files with embedded OCR-text `#perl` `#gtk3`.
+- [gscan2pdf](https://gscan2pdf.sourceforge.net) - Document scanner with cleaning and OCR features (on the scan or imported images incl. PDFs, DjVus or other file types) `#perl` `#gtk3`.
 
 ### Note-taking
 

--- a/README.md
+++ b/README.md
@@ -513,7 +513,8 @@ Clients for commercial social platforms that had their API access cut off in a w
 ### Document Scanners
 
 - [Decoder](https://apps.gnome.org/Decoder) - QR Codes scanner and generator `#rust` `#gtk4` `#libadwaita` `#gnome`.
-- [Document Scanner](https://apps.gnome.org/SimpleScan) - Document scanner using the SANE framework with crop and rotate editing features `#vala` `#libadwaita` `#gnome`.
+- [Document Scanner (SimpleScan)](https://apps.gnome.org/SimpleScan) - Document scanner using the SANE framework with crop and rotate editing features `#vala` `#gtk4``#libadwaita` `#gnome`.
+- [gscan2pdf](https://gscan2pdf.sourceforge.net/) - Document scanner that can scan, clean the scan and do OCR on the scan or imported images (incl. existing PDFs, DjVus or other file types), and make PDF and DjVu-files with embedded OCR-text `#perl` `#gtk3`.
 
 ### Note-taking
 


### PR DESCRIPTION
gscan2pdf -  A GUI to produce PDFs or DjVus from scanned documents. Document scanner that can scan, clean the scan and do OCR on the scan or imported images (incl. existing PDFs, DjVus or other file types), and make PDF and DjVu-files with embedded OCR-text. Perl GTK3
https://gscan2pdf.sourceforge.net/
https://sourceforge.net/p/gscan2pdf/code/ci/master/tree/

I also fixed the entry for Document Scanner (Simple Scan)