### PR TITLE
Add Jogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,7 +940,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [BMI](https://github.com/PhilippKosarev/bmi) - Body mass index (BMI) calculator `#python` `#gtk4` `#libadwaita`.
 - [Dosage](https://github.com/diegopvlk/Dosage) - Medication tracker `#gjs` `#gtk4` `#libadwaita`.
 - [Health](https://apps.gnome.org/Health) - Fitness goals tracker `#rust` `#gtk4` `#libadwaita` `#gnome`.
-- [Jogger](https://codeberg.org/baarkerlounger/jogger) - App for Gnome Mobile to Track running and other workouts `#rust` `#gtk4` `#libadwaita`.
+- [Jogger](https://codeberg.org/baarkerlounger/jogger) - Running (and other workout) tracker for GNOME Mobile with import from Fitotrack  `#rust` `#gtk4` `#libadwaita`.
 
 ## Map Viewers
 

--- a/README.md
+++ b/README.md
@@ -938,8 +938,9 @@ Clients for commercial social platforms that had their API access cut off in a w
 ## Health and Fitness
 
 - [BMI](https://github.com/PhilippKosarev/bmi) - Body mass index (BMI) calculator `#python` `#gtk4` `#libadwaita`.
-- [Health](https://apps.gnome.org/Health) - Fitness goals tracker `#rust` `#gtk4` `#libadwaita` `#gnome`.
 - [Dosage](https://github.com/diegopvlk/Dosage) - Medication tracker `#gjs` `#gtk4` `#libadwaita`.
+- [Health](https://apps.gnome.org/Health) - Fitness goals tracker `#rust` `#gtk4` `#libadwaita` `#gnome`.
+- [Jogger](https://codeberg.org/baarkerlounger/jogger) - App for Gnome Mobile to Track running and other workouts `#rust` `#gtk4` `#libadwaita`.
 
 ## Map Viewers
 


### PR DESCRIPTION
Jogger - An app for Gnome Mobile to Track running and other workouts. Inspired by Fitotrack.

Built with GTK4, Libadwaita, Rust and Sqlite.

https://codeberg.org/baarkerlounger/jogger

& I sorted the category "Health and Fitness" alphabetically