### PR TITLE
Add Claws Mail, Planner, Nemo & PSequel

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [Gnome Commander](https://gitlab.gnome.org/GNOME/gnome-commander) - Fast and powerful twin-panel file manager `#c++` `#rust` `#gtk3`.
 - [Hyperplane](https://github.com/kra-mo/hyperplane) - Non-hierarchical file manager `#python` `#gtk4` `#libadwaita`.
 - [GNOME Files (Nautilus)](https://apps.gnome.org/Nautilus) - Default file manager of the GNOME desktop `#c` `#gtk4` `#libadwaita` `#gnome`.
-- [Nemo](https://github.com/linuxmint/nemo/) - Default file manager of the Cinnamon desktop (fork of Nautilus) `#c` `#gtk3`.
+- [Nemo](https://github.com/linuxmint/nemo) - Default file manager of the Cinnamon desktop (fork of Nautilus) `#c` `#gtk3`.
 - [Organizer](https://gitlab.gnome.org/aviwad/organizer) - Application to organize your files into categories `#python` `#gtk3` `#libhandy`.
 - [Polo](https://github.com/teejee2008/polo) - Multi-pane and tabbed file manager `#vala` `#gtk3`.
 - [Portofolio](https://github.com/tchx84/Portfolio) - File manager for mobile devices `#python` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 ### Email
 
 - [Astroid](https://astroidmail.github.io) - Lightweight and fast Mail User Agent that provides a GUI to searching, displaying and composing email using [notmuch](https://notmuchmail.org) as backend `#c++` `#gtk3`.
-- [Claws Mail](https://claws-mail.org/) - Claws Mail is an email client (and news reader) `#c` `#gtk3`.
+- [Claws Mail](https://claws-mail.org) - Email client with plugin system to extend functionalities (news reader, calendar, etc.)  `#c` `#gtk3`.
 - [Geary](https://gitlab.gnome.org/GNOME/geary) - Email application for the GNOME desktop build around conversations `#vala` `#gtk3` `#libhandy`.
 - [Evolution](https://gitlab.gnome.org/GNOME/evolution) - Personal information management application that provides integrated mail, calendaring and address book functionality `#c` `#gtk3`.
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 ### Email
 
 - [Astroid](https://astroidmail.github.io) - Lightweight and fast Mail User Agent that provides a GUI to searching, displaying and composing email using [notmuch](https://notmuchmail.org) as backend `#c++` `#gtk3`.
+- [Claws Mail](https://claws-mail.org/) - Claws Mail is an email client (and news reader) `#c` `#gtk3`.
 - [Geary](https://gitlab.gnome.org/GNOME/geary) - Email application for the GNOME desktop build around conversations `#vala` `#gtk3` `#libhandy`.
 - [Evolution](https://gitlab.gnome.org/GNOME/evolution) - Personal information management application that provides integrated mail, calendaring and address book functionality `#c` `#gtk3`.
 
@@ -602,6 +603,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 ### Project Management
 
+- [Planner](https://gitlab.gnome.org/World/planner) - Cross-platform project management tool, for planning, scheduling and tracking projects `#c` `#gtk3`.
 - [Planify](https://github.com/alainm23/planify) - Project and task manager with Todoist support `#vala` `#gtk4` `#libadwaita`.
 
 ### Timers / Time Tracking
@@ -824,6 +826,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 ### Database Clients
 
 - [Daty](https://gitlab.gnome.org/World/Daty) - Cross-platform advanced Wikidata editor `#python` `#gtk3` `#libhandy`.
+- [PSequel](https://github.com/ppvan/psequel) - Modern, yet another Postgres SQL client `#vala` `#gtk4` `#libadwaita`.
 - [Sequeler](https://github.com/Alecaddd/sequeler) - SQL client with support for PostgreSQL, MariaDB and SQLite `#vala` `#gtk3` `#granite`.
 
 ### Disk Imaging
@@ -837,7 +840,8 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 - [Gnome Commander](https://gitlab.gnome.org/GNOME/gnome-commander) - Fast and powerful twin-panel file manager `#c++` `#rust` `#gtk3`.
 - [Hyperplane](https://github.com/kra-mo/hyperplane) - Non-hierarchical file manager `#python` `#gtk4` `#libadwaita`.
-- [GNOME Files (Nautilus)](https://apps.gnome.org/Nautilus) - Default file manager of the GNOME desktop `#c` `#gtk4` `#libadwaita` `#gnome`. 
+- [GNOME Files (Nautilus)](https://apps.gnome.org/Nautilus) - Default file manager of the GNOME desktop `#c` `#gtk4` `#libadwaita` `#gnome`.
+- [Nemo](https://github.com/linuxmint/nemo/) - Default file manager of the Cinnamon desktop (fork of Nautilus) `#c` `#gtk3`.
 - [Organizer](https://gitlab.gnome.org/aviwad/organizer) - Application to organize your files into categories `#python` `#gtk3` `#libhandy`.
 - [Polo](https://github.com/teejee2008/polo) - Multi-pane and tabbed file manager `#vala` `#gtk3`.
 - [Portofolio](https://github.com/tchx84/Portfolio) - File manager for mobile devices `#python` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -826,7 +826,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 ### Database Clients
 
 - [Daty](https://gitlab.gnome.org/World/Daty) - Cross-platform advanced Wikidata editor `#python` `#gtk3` `#libhandy`.
-- [PSequel](https://github.com/ppvan/psequel) - Modern, yet another Postgres SQL client `#vala` `#gtk4` `#libadwaita`.
+- [PSequel](https://github.com/ppvan/psequel) - Postgres SQL client `#vala` `#gtk4` `#libadwaita`.
 - [Sequeler](https://github.com/Alecaddd/sequeler) - SQL client with support for PostgreSQL, MariaDB and SQLite `#vala` `#gtk3` `#granite`.
 
 ### Disk Imaging


### PR DESCRIPTION
Nemo - Default file manager of the Cinnamon desktop (fork of Nautilus) C gtk3
https://github.com/linuxmint/nemo/

Planner  - Cross-platform project management tool, for planning, scheduling and tracking projects  C GTK3
https://wiki.gnome.org/Apps/Planner
https://gitlab.gnome.org/World/planner

Claws Mail - Claws Mail is an email client (and news reader)  C GTK3
https://claws-mail.org/
https://git.claws-mail.org/?p=claws.git;a=summary

PSequel - Modern, yet another Postgres SQL client  Vala gtk4 libadwaita
https://github.com/ppvan/psequel