### PR TITLE
Add missing GNOME core apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 - [Internet and Networking](#internet-and-networking)
   - [Bluetooth](#bluetooth)
   - [Chat, VoIP, and Phone](#chat-voip-and-phone)
-  - [Email, Personal information mananagement (PIM)](#email-personal-information-management-(pim))
+  - [Email, Personal information mananagement (PIM)](#email-personal-information-management-pim)
   - [File Sharing](#file-sharing)
   - [Network Configuration](#network-configuration)
   - [Network Monitoring](#network-monitoring)

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 
 - [Astroid](https://astroidmail.github.io) - Lightweight and fast Mail User Agent that provides a GUI to searching, displaying and composing email using [notmuch](https://notmuchmail.org) as backend `#c++` `#gtk3`.
 - [Geary](https://gitlab.gnome.org/GNOME/geary) - Email application for the GNOME desktop build around conversations `#vala` `#gtk3` `#libhandy`.
-- [GNOME Contacts](https://apps.gnome.org/Contacts/) - Adress book for contacts information and contact management for the GNOME desktop `#vala` `#gtk4` `#libadwaita` `#gnome`. 
+- [GNOME Contacts](https://apps.gnome.org/Contacts) - Address book for contacts information and contact management for the GNOME desktop `#vala` `#gtk4` `#libadwaita` `#gnome`. 
 - [Evolution](https://gitlab.gnome.org/GNOME/evolution) - Personal information management (PIM) application that provides integrated mail, calendaring and address book functionality `#c` `#gtk3`.
 
 ### File Sharing

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [Birdfont](https://github.com/johanmattssonm/birdfont) - Font editor for creating fonts in TTF, EOT, SVG and BIRDFONT formats `#vala` `#gtk3`.
 - [Dia](https://gitlab.gnome.org/GNOME/dia) - Diagram editor `#c` `#c++` `#gtk3`.
 - [Font Downloader](https://github.com/GustavoPeredo/font-downloader) - Download utility for Google Fonts `#python` `#gtk3` `#libhandy`.
+- [GNOME Fonts (Font Viewer])(https://apps.gnome.org/FontViewer) - Utility to view and install fonts on your system `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Inkscape](https://inkscape.org) - General vector graphics editor `#c++` `#gtk3`.
 - [Mingle](https://github.com/halfmexican/mingle) - Application to combine emojis using Google's Emoji Kitchen `#vala` `#gtk4` `#libadwaita`.
 - [Pizzara](https://pizarra.categulario.xyz/en) - Digital, vectorial and infinite chalkboard for free-hand drawing `#rust` `#gtk3`.

--- a/README.md
+++ b/README.md
@@ -914,6 +914,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [Door Knocker](https://codeberg.org/tytan652/door-knocker) - Tool to check availability of all `xdg-desktop-portal` portals `#c` `#gtk4` `#libadwaita`.
 - [GNOME Disk Usage Analyzer (Baobab)](https://apps.gnome.org/Baobab) - Disk usage analyzer, also known as Baobab, with DaisyDisk style circle chart `#vala` `#gtk4` `#libadwaita` `#gnome`.
 - [GNOME Logs](https://apps.gnome.org/Logs) - systemd logs viewer `#c` `#gtk4` `#libadwaita` `#gnome`.
+- [GNOME System Monitor](https://apps.gnome.org/SystemMonitor) - Process viewer and system monitor `#c++` `#gtk4` `#libadwaita` `#gnome`.
 - [GNOME Usage](https://gitlab.gnome.org/GNOME/gnome-usage) - System resources monitoring for the GNOME desktop `#vala` `#gtk4` `#libadwaita`.
 - [GreenWithEnvy](https://gitlab.com/leinardi/gwe) - NVIDIA card monitoring and fan/OC controlling application `#python` `#gtk3`.
 - [Inspector](https://github.com/Nokse22/inspector) - Application to view system information such as USB/disk/PCIE/networks devices and motherboard/CPU information `#python` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 - [AdwSteamGtk](https://github.com/Foldex/AdwSteamGtk) - [Adwaita for Steam](https://github.com/tkashkin/Adwaita-for-Steam) skin installer `#python` `#gtk4` `#libadwaita`.
 - [Extension Manager](https://github.com/mjakeman/extension-manager) - Utility for browsing and installing GNOME Shell Extensions `#c` `#gtk4` `#libadwaita`.
+- [GNOME Software](https://apps.gnome.org/Software) - Application to install and update applications (Debian-, RPM-, Flatpak-, and Snap packages, Firmware updates)  `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Icicle](https://github.com/snowfallorg/icicle) - Graphical installer for NixOS based distributions `#rust` `#gtk4` `#libadwaita` `#relm4`.
 - [Impression](https://apps.gnome.org/Impression) - Straight-forward and modern application to create bootable drives `#rust` `#gtk4` `#libadwaita` `#gnome`.
 - [mlinstall](https://petabyt.github.io/mlinstall) - USB Magic Lantern installer `#python` `#gtk3`.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [Birdfont](https://github.com/johanmattssonm/birdfont) - Font editor for creating fonts in TTF, EOT, SVG and BIRDFONT formats `#vala` `#gtk3`.
 - [Dia](https://gitlab.gnome.org/GNOME/dia) - Diagram editor `#c` `#c++` `#gtk3`.
 - [Font Downloader](https://github.com/GustavoPeredo/font-downloader) - Download utility for Google Fonts `#python` `#gtk3` `#libhandy`.
-- [GNOME Fonts (Font Viewer])(https://apps.gnome.org/FontViewer) - Utility to view and install fonts on your system `#c` `#gtk4` `#libadwaita` `#gnome`.
+- [GNOME Fonts (Font Viewer)](https://apps.gnome.org/FontViewer) - Utility to view and install fonts on your system `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Inkscape](https://inkscape.org) - General vector graphics editor `#c++` `#gtk3`.
 - [Mingle](https://github.com/halfmexican/mingle) - Application to combine emojis using Google's Emoji Kitchen `#vala` `#gtk4` `#libadwaita`.
 - [Pizzara](https://pizarra.categulario.xyz/en) - Digital, vectorial and infinite chalkboard for free-hand drawing `#rust` `#gtk3`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 - [Internet and Networking](#internet-and-networking)
   - [Bluetooth](#bluetooth)
   - [Chat, VoIP, and Phone](#chat-voip-and-phone)
-  - [Email, Personal information mananagement (PIM)](#email-personal-information-management-pim)
+  - [Email, Personal information management (PIM)](#email-personal-information-management-pim)
   - [File Sharing](#file-sharing)
   - [Network Configuration](#network-configuration)
   - [Network Monitoring](#network-monitoring)

--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [balistica](https://github.com/fusilero/balistica) - Exterior ballistics calculator `#vala` `#gtk3`.
 - [Binary](https://apps.gnome.org/Binary) - Small application to convert numbers to different bases `#python` `#gtk4` `#libadwaita`.
 - [Dippi](https://github.com/cassidyjames/dippi) - Display DPI calculator `#vala` `#gtk4` `#libadwaita`.
+- [GNOME Calculator](https://apps.gnome.org/Calculator/) - Default calculator for the Gnome desktop for arithmetic, scientific or financial calculations `#vala` `#gtk4` `#libadwaita` `#gnome`.
 - [Gnumeric](http://www.gnumeric.org) - Spreadsheet editor `#c` `#gtk3`.
 - [Graphs](https://apps.gnome.org/Graphs) - Plotting and data manipulation tool for the GNOME desktop `#python` `#gtk4` `#libadwaita` `#gnome`.
 - [Gretl](https://gretl.sourceforge.net) - Cross-platform statistical package for econometric analysis `#c` `#gtk3`.

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [balistica](https://github.com/fusilero/balistica) - Exterior ballistics calculator `#vala` `#gtk3`.
 - [Binary](https://apps.gnome.org/Binary) - Small application to convert numbers to different bases `#python` `#gtk4` `#libadwaita`.
 - [Dippi](https://github.com/cassidyjames/dippi) - Display DPI calculator `#vala` `#gtk4` `#libadwaita`.
-- [GNOME Calculator](https://apps.gnome.org/Calculator/) - Default calculator for the Gnome desktop for arithmetic, scientific or financial calculations `#vala` `#gtk4` `#libadwaita` `#gnome`.
+- [GNOME Calculator](https://apps.gnome.org/Calculator) - Default calculator for the Gnome desktop for arithmetic, scientific or financial calculations `#vala` `#gtk4` `#libadwaita` `#gnome`.
 - [Gnumeric](http://www.gnumeric.org) - Spreadsheet editor `#c` `#gtk3`.
 - [Graphs](https://apps.gnome.org/Graphs) - Plotting and data manipulation tool for the GNOME desktop `#python` `#gtk4` `#libadwaita` `#gnome`.
 - [Gretl](https://gretl.sourceforge.net) - Cross-platform statistical package for econometric analysis `#c` `#gtk3`.

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [Exercise Timer](https://github.com/mfep/exercise-timer) - Interval training timer `#rust` `#gtk4` `#libadwaita` `#relm4`.
 - [Flowtime](https://github.com/Diego-Ivan/Flowtime) - Pomodoro timer with statistics `#vala` `#gtk4` `#libadwaita`.
 - [Furtherance](https://github.com/lakoliu/Furtherance) - Cross-platform time tracker `#rust` `#gtk4` `#libadwaita`.
+- [GNOME Clocks](https://apps.gnome.org/Clocks/) - Clock application including world clocks, alarms, a stopwatch, and timers `#vala` `#gtk4` `#libadwaita` `#gnome`.
 - [hamster-gtk](https://github.com/projecthamster/hamster-gtk) - Time tracker provided by `hamster-lib` `#python` `#gtk3`.
 - [Hourglass](https://github.com/sgpthomas/hourglass) - Simple time keeping application for elementaryOS `#vala` `#gtk4` `#granite`.
 - [Khronos](https://apps.gnome.org/Khronos) - Task time logger `#vala` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [Paper Plane](https://github.com/paper-plane-developers/paper-plane) - Telegram client for the GNOME desktop `#rust` `#gtk4` `#libadwaita`.
 - [Srain](https://srain.silverrainz.me) - Modern IRC client `#c` `#gtk3`.
 
-### Email, Personal information mananagement (PIM)
+### Email, Personal information management (PIM)
 
 - [Astroid](https://astroidmail.github.io) - Lightweight and fast Mail User Agent that provides a GUI to searching, displaying and composing email using [notmuch](https://notmuchmail.org) as backend `#c++` `#gtk3`.
 - [Geary](https://gitlab.gnome.org/GNOME/geary) - Email application for the GNOME desktop build around conversations `#vala` `#gtk3` `#libhandy`.

--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [EasySSH](https://github.com/muriloventuroso/easyssh) - SSH connection manager `#vala` `#gtk3`.
 - [Flatseal](https://github.com/tchx84/Flatseal) - Flatpak permission manager `#gjs` `#gtk4` `#libadwaita`.
 - [FlatSync](https://gitlab.gnome.org/Cogitri/flatsync) - GUI to synchronise Flatpak packages across devices `#rust` `#gtk4` `#libadwaita`.
+- [GNOME Disks (disk utility](https://apps.gnome.org/DiskUtility) - Disk management utility for the GNOME desktop to inspect, format, partition, and configure disks and block devices `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Hidamari](https://github.com/jeffshee/hidamari) - Application to configure video wallpaper for X11 and Wayland `#python` `#gtk3`.
 - [Lan Mouse](https://github.com/feschber/lan-mouse) - Mouse and keyboard sharing software (software KVM switch) designed for Wayland `#rust` `#gtk4` `#libadwaita`.
 - [Login Manager Settings](https://gdm-settings.github.io) - GNOME's Login Manager (GDM) settings manager `#python` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 - [Internet and Networking](#internet-and-networking)
   - [Bluetooth](#bluetooth)
   - [Chat, VoIP, and Phone](#chat-voip-and-phone)
-  - [Email](#email)
+  - [Email, Personal information mananagement (PIM)](#email-personal-information-management-(pim))
   - [File Sharing](#file-sharing)
   - [Network Configuration](#network-configuration)
   - [Network Monitoring](#network-monitoring)
@@ -386,11 +386,12 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [Paper Plane](https://github.com/paper-plane-developers/paper-plane) - Telegram client for the GNOME desktop `#rust` `#gtk4` `#libadwaita`.
 - [Srain](https://srain.silverrainz.me) - Modern IRC client `#c` `#gtk3`.
 
-### Email
+### Email, Personal information mananagement (PIM)
 
 - [Astroid](https://astroidmail.github.io) - Lightweight and fast Mail User Agent that provides a GUI to searching, displaying and composing email using [notmuch](https://notmuchmail.org) as backend `#c++` `#gtk3`.
 - [Geary](https://gitlab.gnome.org/GNOME/geary) - Email application for the GNOME desktop build around conversations `#vala` `#gtk3` `#libhandy`.
-- [Evolution](https://gitlab.gnome.org/GNOME/evolution) - Personal information management application that provides integrated mail, calendaring and address book functionality `#c` `#gtk3`.
+- [GNOME Contacts](https://apps.gnome.org/Contacts/) - Adress book for contacts information and contact management for the GNOME desktop `#vala` `#gtk4` `#libadwaita` `#gnome`. 
+- [Evolution](https://gitlab.gnome.org/GNOME/evolution) - Personal information management (PIM) application that provides integrated mail, calendaring and address book functionality `#c` `#gtk3`.
 
 ### File Sharing
 


### PR DESCRIPTION
Add 7 missing GNOME core apps from the official list of GNOME core apps: https://apps.gnome.org/ (first section)

These commits add:
- GNOME Calculator
- GNOME Clocks
- GNOME Contacts
- GNOME Disks
- GNOME Fonts (Font Viewer)
- GNOME Software
- GNOME System Monitor
