### PR TITLE
Fixed typos with backticks (`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 ### Video Players
 
 - [Celluloid](https://github.com/celluloid-player/celluloid) - (ex GNOME MPV) frontend for MPV `#c` `#gtk4` `#libadwaita`.
-- [Clapper](https://github.com/Rafostar/clapper) - Media player powered by GStreamer with OpenGL rendering `#gjs` `#c` `#gtk4` #libadwaita`.
+- [Clapper](https://github.com/Rafostar/clapper) - Media player powered by GStreamer with OpenGL rendering `#gjs` `#c` `#gtk4` `#libadwaita`.
 - [Delfin](https://codeberg.org/avery42/delfin) - Application to stream movies/TV shows from Jellyfin `#rust` `#gtk4` `#libadwaita`.
 - [GNOME Videos (Totem)](https://apps.gnome.org/Totem) - Official GNOME desktop video player, also known as Totem `#c` `#gtk3`. `#gnome`.
 - [Glide](https://github.com/philn/glide) - Simple video player powered by GStreamer `#rust` `#gtk4` `#libadwaita`.
@@ -559,7 +559,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 ### Document Scanners
 
 - [Decoder](https://apps.gnome.org/Decoder) - QR Codes scanner and generator `#rust` `#gtk4` `#libadwaita` `#gnome`.
-- [Document Scanner (SimpleScan)](https://apps.gnome.org/SimpleScan) - Document scanner using the SANE framework with crop and rotate editing features `#vala` `#gtk4``#libadwaita` `#gnome`.
+- [Document Scanner (SimpleScan)](https://apps.gnome.org/SimpleScan) - Document scanner using the SANE framework with crop and rotate editing features `#vala` `#gtk4` `#libadwaita` `#gnome`.
 - [gscan2pdf](https://gscan2pdf.sourceforge.net) - Document scanner with cleaning and OCR features (on the scan or imported images incl. PDFs, DjVus or other file types) `#perl` `#gtk3`.
 
 ### Note-taking


### PR DESCRIPTION
Some inline code blocks weren't displaying correctly due to typos with the backticks (`)