### PR TITLE
Changed the previous Atlas to Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,7 +1307,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 ## Map Viewers
 
 - [GNOME Maps](https://apps.gnome.org/Maps) - GNOME's map viewer using OpenStreetMap database `#gjs` `#javascript` `#libadwaita` `#gtk4` `#gnome` .
-- [Maps](https://github.com/elementary/maps) - Map viewer designed for elementaryOS `#vala` `#gtk4` `#granite` `#libadwaita`.
+- [Maps](https://github.com/elementary/maps) - Map viewer designed for elementary OS `#vala` `#gtk4` `#granite` `#libadwaita`.
 
 
 ## Public Transports

--- a/README.md
+++ b/README.md
@@ -1309,7 +1309,6 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [GNOME Maps](https://apps.gnome.org/Maps) - GNOME's map viewer using OpenStreetMap database `#gjs` `#javascript` `#libadwaita` `#gtk4` `#gnome` .
 - [Maps](https://github.com/elementary/maps) - Map viewer designed for elementary OS `#vala` `#gtk4` `#granite` `#libadwaita`.
 
-
 ## Public Transports
 
 - [Passes](https://flathub.org/apps/me.sanchezrodriguez.passes) - Application to manage digital passes in PKPass or esPass format, such as boarding passes, bus tickets, coupons, loyalty cards, event tickets, etc. `#python` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -1306,8 +1306,9 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 ## Map Viewers
 
-- [Atlas](https://github.com/ryonakano/atlas) - Map viewer designed for elementaryOS `#vala` `#gtk4` `#granite`.
 - [GNOME Maps](https://apps.gnome.org/Maps) - GNOME's map viewer using OpenStreetMap database `#gjs` `#javascript` `#libadwaita` `#gtk4` `#gnome` .
+- [Maps](https://github.com/elementary/maps) - Map viewer designed for elementaryOS `#vala` `#gtk4` `#granite` `#libadwaita`.
+
 
 ## Public Transports
 


### PR DESCRIPTION
The previous elementary Atlas application now links to the forked elementary maps.

https://github.com/ryonakano/atlas (old link that redirects to the new maps)
https://github.com/elementary/maps (new link)

Elementary maps supports both, libadwaita and granite
https://github.com/elementary/maps/blob/main/src/meson.build