### PR TITLE
Removed Refract, as it is iced-based not gtk since 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,6 @@ this list aims to be broader and include apps from various other ecosystems in v
 
 - [Curtail](https://apps.gnome.org/Curtail) - Image compressor with support for PNG, JPEG, WebP and SVG images `#python` `#gtk4` `#libadwaita` `#gnome`.
 - [Image Optimizer](https://flathub.org/en/apps/com.github.gijsgoudzwaard.image-optimizer) - Simple lossless image optimizer for elementary OS  `#vala` `#gtk3` `#granite`.
-- [Refract](https://github.com/Blobfolio/refract) - _Guided_ image optimization for JPEGs and PNGs producing WebP, AVIF and JPEG XL clones `#rust` `#gtk3`.
 
 #### Photography
 


### PR DESCRIPTION
v. 1.0 14.02.2025

The refract GUI has been completely rewritten for this release, replacing GTK3 with the more Rust-centric and cross-platform iced library.

https://github.com/Blobfolio/refract/releases/tag/v1.0.0