### PR TITLE
Add N01D Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [GNOME Terminal](https://gitlab.gnome.org/GNOME/gnome-terminal) - Terminal for the GNOME desktop `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Guake](https://github.com/Guake/guake) - Dropdown terminal for the GNOME desktop `#python` `#gtk3`.
 - [Ptyxis](https://gitlab.gnome.org/chergert/ptyxis) - Terminal with first-class support for containers `#c` `#gtk4` `#libadwaita`.
+- [N01D Terminal](https://github.com/bad-antics/n01d-term) - Cyberpunk-themed hacker terminal emulator with custom prompts and matrix effects `#python` `#gtk4`.
 - [Tilix](https://gnunn1.github.io/tilix-web) - Tiling and dropdown terminal for the GNOME desktop `#d` `#gtk3`.
 
 ### Text Processing


### PR DESCRIPTION
Adds N01D Terminal to the Terminals section.

## N01D Terminal
A cyberpunk-themed hacker terminal emulator with:
- Custom hacker-style prompts
- Matrix rain effects
- GTK4 interface
- Designed for security researchers

**Repository:** https://github.com/bad-antics/n01d-term

`#python` `#gtk4`