### PR TITLE
Add FlyCrys to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,7 +958,8 @@ Clients for commercial social platforms that had their API access cut off in a w
 
 ### Development Tools
 
-- [D-Spy](https://flathub.org/en/apps/org.gnome.dspy) - Simple tool to explore D-Bus connections `#c` `#gtk4` `#libadwaita` `#gnome`. 
+- [D-Spy](https://flathub.org/en/apps/org.gnome.dspy) - Simple tool to explore D-Bus connections `#c` `#gtk4` `#libadwaita` `#gnome`.
+- [FlyCrys](https://github.com/SergKam/FlyCrys) - Native GUI for Claude Code AI agents with file tree, text viewer, embedded terminal, and multi-workspace support `#rust` `#gtk4`.
 - [Schemes](https://flathub.org/en/apps/app.devsuite.Schemes) - Application to create syntax highlighting style-schemes for GtkSourceView-based applications such as Builder or Text Editor `#c` `#gtk4` `#libadwaita`.
 - [Sysprof](https://apps.gnome.org/Sysprof) - Application to profile an application or entire system, to aid in debugging and optimization `#c` `#gtk4` `#libadwaita` `#gnome`.
 - [Translation Editor (Gtranslator)](https://flathub.org/en/apps/org.gnome.Gtranslator) - Enhanced gettext `.po` file editor for the GNOME desktop to translate applications `#c` `#gtk4` `#libadwaita` `#gnome`.


### PR DESCRIPTION
## Summary

Add [FlyCrys](https://github.com/SergKam/FlyCrys) to the **Development Tools** section.

**FlyCrys** is a native Linux GUI for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) AI agents, built with **Rust + GTK4** (pure GTK4, no libadwaita dependency).

### Features

- File tree with MIME-type icons
- Syntax-highlighted text viewer (GtkSourceView)
- Embedded VTE4 terminal
- Agent chat interface
- Multiple workspaces with tabbed layout

### Details

- **Language**: Rust
- **Toolkit**: GTK4
- **License**: MIT
- **Repository**: https://github.com/SergKam/FlyCrys