### PR TITLE
Added Nocturne

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [Monophony](https://gitlab.com/zehkira/monophony) - Application for streaming music from YouTube `#python` `#gtk4` `#libadwaita`.
 - [Muzika](https://github.com/vixalien/muzika) - Music player with customizable home screen and Google Music integration `#gjs` `#typescript` `#gtk4` `#libadwaita`.
 - [NetEase Cloud Music Gtk4](https://flathub.org/en/apps/com.github.gmg137.netease-cloud-music-gtk) - Audio player for NetEase Cloud Music `#rust` `#gtk4` `#libadwaita`.
+- [Nocturne](https://flathub.org/en/apps/com.jeffser.Nocturne) - Music player and library manager with MPRIS support, automatic lyrics fechting, and compatible with Jellyfin, OpenSubsonic and local files `#python` `#gtk4` `#libadwaita`.
 - [Plattenalbum](https://flathub.org/en/apps/de.wagnermartin.Plattenalbum) - MPD client focusing on album playing `#python` `#gtk4` `#libadwaita`.
 - [Quod Libet](https://github.com/quodlibet/quodlibet) - Cross-platform audio player providing many different ways to view local libraries `#python` `#gtk3`.
 - [Resonance](https://github.com/nate-xyz/resonance) - Music player with MPRIS support, Discord Rich presence and Last.fm scrobbling `#rust` `#python` `#gtk4` `#libadwaita`.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [Monophony](https://gitlab.com/zehkira/monophony) - Application for streaming music from YouTube `#python` `#gtk4` `#libadwaita`.
 - [Muzika](https://github.com/vixalien/muzika) - Music player with customizable home screen and Google Music integration `#gjs` `#typescript` `#gtk4` `#libadwaita`.
 - [NetEase Cloud Music Gtk4](https://flathub.org/en/apps/com.github.gmg137.netease-cloud-music-gtk) - Audio player for NetEase Cloud Music `#rust` `#gtk4` `#libadwaita`.
-- [Nocturne](https://flathub.org/en/apps/com.jeffser.Nocturne) - Music player and library manager with MPRIS support, automatic lyrics fechting, and compatible with Jellyfin, OpenSubsonic and local files `#python` `#gtk4` `#libadwaita`.
+- [Nocturne](https://jeffser.com/nocturne) - Music player and library manager with MPRIS support, automatic lyrics fechting, and compatible with Jellyfin, OpenSubsonic and local files `#python` `#gtk4` `#libadwaita`.
 - [Plattenalbum](https://flathub.org/en/apps/de.wagnermartin.Plattenalbum) - MPD client focusing on album playing `#python` `#gtk4` `#libadwaita`.
 - [Quod Libet](https://github.com/quodlibet/quodlibet) - Cross-platform audio player providing many different ways to view local libraries `#python` `#gtk3`.
 - [Resonance](https://github.com/nate-xyz/resonance) - Music player with MPRIS support, Discord Rich presence and Last.fm scrobbling `#rust` `#python` `#gtk4` `#libadwaita`.


### PR DESCRIPTION
- [Nocturne](https://flathub.org/en/apps/com.jeffser.Nocturne) - Music player and library manager with MPRIS support, automatic lyrics fechting, and compatible with Jellyfin, OpenSubsonic and local files `#python` `#gtk4` `#libadwaita`.

https://www.phoronix.com/news/Nocturne-1.0-GNOME-Music